### PR TITLE
Remove updatedAt from TimerDetails

### DIFF
--- a/src/main/java/org/example/model/dto/TimerDetails.java
+++ b/src/main/java/org/example/model/dto/TimerDetails.java
@@ -6,7 +6,6 @@ public class TimerDetails {
     private Long id;
     private String name;
     private LocalDateTime createdAt;
-    private LocalDateTime updatedAt;
     private Integer workDuration;
     private Integer breakDuration;
     private Integer pomodoroCount;
@@ -44,14 +43,6 @@ public class TimerDetails {
 
     public void setCreatedAt(LocalDateTime createdAt) {
         this.createdAt = createdAt;
-    }
-
-    public LocalDateTime getUpdatedAt() {
-        return updatedAt;
-    }
-
-    public void setUpdatedAt(LocalDateTime updatedAt) {
-        this.updatedAt = updatedAt;
     }
 
     public Integer getWorkDuration() {


### PR DESCRIPTION
To reflect a change in the backend in naedher/pomodoro-timer-api#54. Do not merge this before the backend is updated because it would lead to mismatched bodies, which will cause mapping errors.