### PR TITLE
Handle JsonProcessingException in the service

### DIFF
--- a/src/main/java/org/example/controller/Main.java
+++ b/src/main/java/org/example/controller/Main.java
@@ -57,11 +57,7 @@ public class Main {
     public void testRegister() {
         System.out.println("Testing registration...");
         CompletableFuture<String> registerFuture = null;
-        try {
-            registerFuture = authService.register(new AuthRequest("test123456@example.com", "testpassword"));
-        } catch (JsonProcessingException e) {
-            throw new RuntimeException(e);
-        }
+        registerFuture = authService.register(new AuthRequest("test123456@example.com", "testpassword"));
 
         registerFuture.thenAccept(token -> {
             System.out.println("Registration successful! Token: " + token.substring(0, 10) + "...");
@@ -120,11 +116,7 @@ public class Main {
                 ", pomodoroCount=" + pomodoroCount);
 
         CompletableFuture<Void> createFuture = null;
-        try {
-            createFuture = timerService.createTimer(new TimerCreate(name, workDuration, shortBreakDuration, longBreakDuration, pomodoroCount));
-        } catch (JsonProcessingException e) {
-            throw new RuntimeException(e);
-        }
+        createFuture = timerService.createTimer(new TimerCreate(name, workDuration, shortBreakDuration, longBreakDuration, pomodoroCount));
         createFuture.thenAccept(v -> {
             System.out.println("Timer created successfully!");
         }).exceptionally(throwable -> {
@@ -216,12 +208,7 @@ public class Main {
 
         // Call updateTimer once and handle the result properly
         CompletableFuture<Void> updateFuture = null;
-        try {
-            updateFuture = timerService.updateTimer(timerId, update);
-        } catch (JsonProcessingException e) {
-            e.printStackTrace();
-            throw new RuntimeException(e);
-        }
+        updateFuture = timerService.updateTimer(timerId, update);
 
         updateFuture.thenAccept(v -> {
             System.out.println("Timer updated successfully!");

--- a/src/main/java/org/example/model/service/TimerService.java
+++ b/src/main/java/org/example/model/service/TimerService.java
@@ -10,8 +10,8 @@ import java.util.List;
 
 public interface TimerService {
     CompletableFuture<TimerDetails> getTimerDetails(long id);
-    CompletableFuture<Void> createTimer(TimerCreate timer) throws JsonProcessingException;
-    CompletableFuture<Void> updateTimer(long id, TimerUpdate request) throws JsonProcessingException;
+    CompletableFuture<Void> createTimer(TimerCreate timer);
+    CompletableFuture<Void> updateTimer(long id, TimerUpdate request);
     CompletableFuture<Void> deleteTimer(long id);
     CompletableFuture<List<TimerDetails>> getUserTimers();
 }

--- a/src/main/java/org/example/model/service/impl/AuthServiceImpl.java
+++ b/src/main/java/org/example/model/service/impl/AuthServiceImpl.java
@@ -32,8 +32,13 @@ public class AuthServiceImpl implements AuthService {
     }
 
     @Override
-    public CompletableFuture<String> register(AuthRequest authRequest) throws JsonProcessingException {
-        String jsonBody = mapper.writeValueAsString(authRequest);
+    public CompletableFuture<String> register(AuthRequest authRequest) {
+        String jsonBody;
+        try {
+            jsonBody = mapper.writeValueAsString(authRequest);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
         return apiClient.post("/auth/register", jsonBody)
                 .thenApply(response -> {
                     try {

--- a/src/main/java/org/example/model/service/impl/TimerServiceImpl.java
+++ b/src/main/java/org/example/model/service/impl/TimerServiceImpl.java
@@ -55,15 +55,25 @@ public class TimerServiceImpl implements TimerService {
     }
 
     @Override
-    public CompletableFuture<Void> createTimer(TimerCreate timer) throws JsonProcessingException {
-        String jsonBody = mapper.writeValueAsString(timer);
+    public CompletableFuture<Void> createTimer(TimerCreate timer) {
+        String jsonBody;
+        try {
+            jsonBody = mapper.writeValueAsString(timer);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
         apiClient.post("/timers", jsonBody);
         return CompletableFuture.completedFuture(null);
     }
 
     @Override
-    public CompletableFuture<Void> updateTimer(long id, TimerUpdate request) throws JsonProcessingException {
-        String jsonBody = mapper.writeValueAsString(request);
+    public CompletableFuture<Void> updateTimer(long id, TimerUpdate request) {
+        String jsonBody;
+        try {
+            jsonBody = mapper.writeValueAsString(request);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
         apiClient.put("/timers/" + id, jsonBody);
         return CompletableFuture.completedFuture(null);
     }


### PR DESCRIPTION
Don't throw `JsonProcessingException` from the service, instead wrap it in a `RuntimeException`.

This makes working with the service much easier and cleaner since it removes the need to have a try-catch block around most service methods.