### PR TITLE
Edit timer

### DIFF
--- a/src/main/java/org/example/controller/TimerController.java
+++ b/src/main/java/org/example/controller/TimerController.java
@@ -31,14 +31,11 @@ public class TimerController {
 
     private TimerGuiManager timerGuiManager;
     private TimerListManager listManager;
+    // we simply get factory class here, it chooses which logic will work.
     private final TimerService timerService = TimerServiceFactory.get();
 
     @FXML
     public void initialize() {
-
-        // Create TimerService
-        // instantiating TimerService here for compatibility with future features.
-        // we simply get factory class here, it chooses which logic will work.
 
 
         // Create TimerGui

--- a/src/main/java/org/example/controller/TimerController.java
+++ b/src/main/java/org/example/controller/TimerController.java
@@ -1,12 +1,21 @@
 package org.example.controller;
 
+import javafx.application.Platform;
 import javafx.fxml.FXML;
+import javafx.fxml.FXMLLoader;
+import javafx.scene.Parent;
+import javafx.scene.Scene;
 import javafx.scene.control.*;
+import javafx.stage.Modality;
+import javafx.stage.Stage;
 import org.example.service.TimerServiceFactory;
 import org.example.model.TimerDetails;
 import org.example.service.interfaces.TimerService;
 import org.example.manager.TimerGuiManager;
 import org.example.manager.TimerListManager;
+import org.example.utils.Utils;
+
+import java.io.IOException;
 
 public class TimerController {
 
@@ -22,6 +31,7 @@ public class TimerController {
 
     private TimerGuiManager timerGuiManager;
     private TimerListManager listManager;
+    private final TimerService timerService = TimerServiceFactory.get();
 
     @FXML
     public void initialize() {
@@ -36,8 +46,32 @@ public class TimerController {
 
         // Create ListManager
         this.listManager = new TimerListManager(this, timerService, timerGuiManager);
+        this.listManager = new TimerListManager(this, timerService, timerGuiManager);
+        addContextMenu();
     }
+    private void addContextMenu() {
+        timerListView.setCellFactory(lv -> {
+            ListCell<TimerDetails> cell = new ListCell<>() {
+                @Override
+                protected void updateItem(TimerDetails item, boolean empty) {
+                    super.updateItem(item, empty);
+                    setText(empty || item == null ? null : item.getName());
+                }
+            };
 
+            MenuItem edit = new MenuItem("Edit");
+            edit.setOnAction(e -> openEditDialog(cell.getItem()));
+            MenuItem delete = new MenuItem("Delete");
+            delete.setOnAction(e -> handleDelete(cell.getItem()));
+
+            ContextMenu cm = new ContextMenu(edit, delete);
+
+            cell.emptyProperty().addListener((obs, wasEmpty, isEmpty) ->
+                    cell.setContextMenu(isEmpty ? null : cm));
+
+            return cell;
+        });
+    }
     @FXML
     private void addSavedTimer() {
         listManager.addSavedTimer();
@@ -60,6 +94,44 @@ public class TimerController {
     private void handleDebug() {
         // Set timer to 3 seconds for testing
         timerGuiManager.debug();
+    }
+    // delete selected timer
+    private void handleDelete(TimerDetails timer) {
+        Alert confirm = new Alert(Alert.AlertType.CONFIRMATION,
+                "Delete timer '" + timer.getName() + "'?", ButtonType.OK, ButtonType.CANCEL);
+        confirm.showAndWait().ifPresent(btn -> {
+            if (btn == ButtonType.OK) {
+                timerService.deleteTimer(timer.getId())
+                        .thenRun(() -> Platform.runLater(listManager::updateTimerList))
+                        .exceptionally(ex -> {                       // UI-friendly error
+                            Platform.runLater(() ->
+                                    Utils.showAlert("Delete error", ex.getCause().getMessage()));
+                            return null;
+                        });
+            }
+        });
+    }
+    private void openEditDialog(TimerDetails timer) {
+        try {
+            FXMLLoader loader =
+                    new FXMLLoader(getClass().getResource("/org/example/app/UpdateTimer.fxml"));
+            Parent root = loader.load();
+
+            UpdateTimerController ctrl = loader.getController();
+            ctrl.init(timer);
+
+            Stage stage = new Stage();
+            ctrl.setStage(stage);
+
+            stage.initModality(Modality.APPLICATION_MODAL);
+            stage.setScene(new Scene(root));
+            stage.setTitle("Edit timer");
+            stage.showAndWait();
+
+            listManager.updateTimerList();
+        } catch (IOException ex) {
+            Utils.showAlert("Dialog error", ex.getMessage());
+        }
     }
 
     public void setTimerLabelText(String text) {

--- a/src/main/java/org/example/controller/TimerController.java
+++ b/src/main/java/org/example/controller/TimerController.java
@@ -39,14 +39,14 @@ public class TimerController {
         // Create TimerService
         // instantiating TimerService here for compatibility with future features.
         // we simply get factory class here, it chooses which logic will work.
-        TimerService timerService = TimerServiceFactory.get();
+
 
         // Create TimerGui
         this.timerGuiManager = new TimerGuiManager(this);
 
         // Create ListManager
         this.listManager = new TimerListManager(this, timerService, timerGuiManager);
-        this.listManager = new TimerListManager(this, timerService, timerGuiManager);
+
         addContextMenu();
     }
     private void addContextMenu() {

--- a/src/main/java/org/example/controller/UpdateTimerController.java
+++ b/src/main/java/org/example/controller/UpdateTimerController.java
@@ -1,5 +1,6 @@
 package org.example.controller;
 
+import javafx.application.Platform;
 import javafx.fxml.FXML;
 import javafx.scene.control.*;
 import javafx.stage.Stage;
@@ -51,6 +52,7 @@ public class UpdateTimerController {
 
     private void handleSave() {
         TimerUpdate req = new TimerUpdate(
+                original.getId(),
                 nameField.getText(),
                 workSpinner.getValue(),
                 shortBreakSpinner.getValue(),
@@ -58,9 +60,10 @@ public class UpdateTimerController {
                 intervalSpinner.getValue()
         );
         timerService.updateTimer(original.getId(), req)
-                .thenRun(() -> stage.close())
+                .thenRun(() -> Platform.runLater(stage::close))
                 .exceptionally(ex -> {
-                    Utils.showAlert("Update error", ex.getCause().getMessage());
+                    Platform.runLater(() ->
+                            Utils.showAlert("Update error", ex.getCause().getMessage()));
                     return null;
                 });
     }

--- a/src/main/java/org/example/controller/UpdateTimerController.java
+++ b/src/main/java/org/example/controller/UpdateTimerController.java
@@ -1,0 +1,72 @@
+package org.example.controller;
+
+import javafx.fxml.FXML;
+import javafx.scene.control.*;
+import javafx.stage.Stage;
+import org.example.model.TimerDetails;
+import org.example.model.TimerUpdate;
+import org.example.service.TimerServiceFactory;
+import org.example.service.interfaces.TimerService;
+import org.example.utils.Utils;
+
+public class UpdateTimerController {
+
+    @FXML private TextField nameField;
+    @FXML private Spinner<Integer> workSpinner;
+    @FXML private Spinner<Integer> shortBreakSpinner;
+    @FXML private Spinner<Integer> longBreakSpinner;
+    @FXML private Spinner<Integer> intervalSpinner;
+    @FXML private Button saveButton;
+
+    private TimerDetails original;
+    private Stage stage;
+    private final TimerService timerService = TimerServiceFactory.get();
+
+    @FXML
+    private void initialize() {
+        initSpinners();
+        saveButton.setOnAction(e -> handleSave());
+    }
+
+    private void initSpinners() {
+        addSpinnerValueFactory(workSpinner,        5, 999);
+        addSpinnerValueFactory(shortBreakSpinner,  1, 999);
+        addSpinnerValueFactory(longBreakSpinner,   1, 999);
+        addSpinnerValueFactory(intervalSpinner,    1, 999);
+    }
+
+    private void addSpinnerValueFactory(Spinner<Integer> spinner, int lower, int upper) {
+        spinner.setValueFactory(new SpinnerValueFactory.IntegerSpinnerValueFactory(lower, upper));
+    }
+
+    //Called by TimerController before the dialog is shown.
+    public void init(TimerDetails timer) {
+        this.original = timer;
+        nameField.setText(timer.getName());
+        workSpinner.getValueFactory().setValue(timer.getWorkDuration());
+        shortBreakSpinner.getValueFactory().setValue(timer.getShortBreakDuration());
+        longBreakSpinner.getValueFactory().setValue(timer.getLongBreakDuration());
+        intervalSpinner.getValueFactory().setValue(timer.getPomodoroCount());
+    }
+
+    private void handleSave() {
+        TimerUpdate req = new TimerUpdate(
+                nameField.getText(),
+                workSpinner.getValue(),
+                shortBreakSpinner.getValue(),
+                longBreakSpinner.getValue(),
+                intervalSpinner.getValue()
+        );
+        timerService.updateTimer(original.getId(), req)
+                .thenRun(() -> stage.close())
+                .exceptionally(ex -> {
+                    Utils.showAlert("Update error", ex.getCause().getMessage());
+                    return null;
+                });
+    }
+
+    public void setStage(Stage stage) {
+        this.stage = stage;
+    }
+}
+

--- a/src/main/java/org/example/manager/TimerListManager.java
+++ b/src/main/java/org/example/manager/TimerListManager.java
@@ -71,6 +71,7 @@ public class TimerListManager {
                 timerGuiManager.reset();
             }
             timerGuiManager.update();
+           updateTimerList();
         });
     }
 }

--- a/src/main/java/org/example/manager/TimerListManager.java
+++ b/src/main/java/org/example/manager/TimerListManager.java
@@ -53,7 +53,7 @@ public class TimerListManager {
         updateTimerList();
     }
 
-    protected void updateTimerList() {
+    public void updateTimerList() {
         timerService.getUserTimers()
                 .thenAccept(list -> Platform.runLater(() -> timerController.getTimerListView().setItems(
                         FXCollections.observableArrayList(list))))

--- a/src/main/java/org/example/model/TimerUpdate.java
+++ b/src/main/java/org/example/model/TimerUpdate.java
@@ -3,20 +3,22 @@ package org.example.model;
 import java.time.LocalDateTime;
 
 public class TimerUpdate {
+    private Long   id;
     private String name;
     private int workDuration;
     private int shortBreakDuration;
     private int longBreakDuration;
     private int pomodoroCount;
 
-    public TimerUpdate(String name, int workDuration, int shortBreakDuration, int longBreakDuration, int pomodoroCount) {
+    public TimerUpdate(Long id,String name, int workDuration, int shortBreakDuration, int longBreakDuration, int pomodoroCount) {
+        this.id = id;
         this.name = name;
         this.workDuration = workDuration;
         this.shortBreakDuration = shortBreakDuration;
         this.longBreakDuration = longBreakDuration;
         this.pomodoroCount = pomodoroCount;
     }
-
+    public Long getId() { return id; }
     public TimerUpdate() { }
 
     public String getName() {

--- a/src/main/java/org/example/service/RemoteTimerService.java
+++ b/src/main/java/org/example/service/RemoteTimerService.java
@@ -69,20 +69,16 @@ public class RemoteTimerService implements TimerService {
     }
 
     @Override
-    public CompletableFuture<TimerDetails> updateTimer(long id, TimerUpdate request) {
-        String jsonBody;
-        try {
-            jsonBody = mapper.writeValueAsString(request);
-        } catch (JsonProcessingException e) {
-            return CompletableFuture.failedFuture(e);
-        }
-        return apiClient.put("/timers/" + id, jsonBody)
-                .thenApply(response -> {
-                    try {
-                        return mapper.readValue(response, TimerDetails.class);
-                    } catch (JsonProcessingException e) {
-                        throw new RuntimeException(e);
-                    }
+    public CompletableFuture<TimerDetails> updateTimer(long id, TimerUpdate req) {
+        String json;
+        try { json = mapper.writeValueAsString(req); }
+        catch (JsonProcessingException e) { return CompletableFuture.failedFuture(e); }
+
+        return apiClient.put("/timers/" + id, json)
+                .thenApply(body -> {
+                    if (body == null || body.isBlank()) return null;
+                    try { return mapper.readValue(body, TimerDetails.class); }
+                    catch (JsonProcessingException e) { throw new RuntimeException(e); }
                 });
     }
 

--- a/src/main/java/org/example/service/RemoteTimerService.java
+++ b/src/main/java/org/example/service/RemoteTimerService.java
@@ -88,7 +88,6 @@ public class RemoteTimerService implements TimerService {
 
     @Override
     public CompletableFuture<Void> deleteTimer(long id) {
-        apiClient.delete("/timers/" + id);
-        return CompletableFuture.completedFuture(null);
+        return apiClient.delete("/timers/" + id);
     }
 }

--- a/src/main/resources/org/example/app/UpdateTimer.fxml
+++ b/src/main/resources/org/example/app/UpdateTimer.fxml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import javafx.scene.control.Spinner?>
+<?import javafx.scene.layout.VBox?>
+<?import javafx.scene.control.TextField?>
+<?import javafx.scene.control.Button?>
+<VBox xmlns:fx="http://javafx.com/fxml"
+      fx:controller="org.example.controller.UpdateTimerController"
+      spacing="10" alignment="CENTER" prefWidth="300">
+
+    <TextField fx:id="nameField" promptText="Name"/>
+    <Spinner fx:id="workSpinner"/>
+    <Spinner fx:id="shortBreakSpinner"/>
+    <Spinner fx:id="longBreakSpinner"/>
+    <Spinner fx:id="intervalSpinner"/>
+    <Button fx:id="saveButton" text="Save"/>
+</VBox>


### PR DESCRIPTION
Timer CRUD operations work now (guest & logged-in)
Right-click → Edit / Delete on any timer.
Edit: modal sends PUT /timers/{id} (body now includes id, we missed it before).
Delete: confirmation, then DELETE /timers/{id}.
Works with InMemoryTimerService (guest) and RemoteTimerService (auth) — DB and UI stay in sync.