### PR TITLE
Fix intervals

### DIFF
--- a/src/main/java/org/example/controller/TimerController.java
+++ b/src/main/java/org/example/controller/TimerController.java
@@ -83,7 +83,7 @@ public class TimerController {
     // Method to reset the timer
     @FXML
     private void reset() {
-        timerGuiManager.reset();
+        timerGuiManager.resetIntervalAndTime();
     }
 
     // Method to handle debug button action

--- a/src/main/java/org/example/manager/TimerGuiManager.java
+++ b/src/main/java/org/example/manager/TimerGuiManager.java
@@ -33,7 +33,7 @@ public class TimerGuiManager {
         this.modeMapping = initModeMapping();
         initModeGroup();
 
-        update();
+        updateDisplay();
     }
 
     private Map<ToggleButton, TimerMode> initModeMapping() {
@@ -67,7 +67,7 @@ public class TimerGuiManager {
     private void handleModeButton(ToggleButton button) {
         TimerMode mode = modeMapping.get(button);
         timerManager.setMode(mode);
-        reset();
+        resetTime();
         setStartButtonText(StartPause.START);
     }
 
@@ -93,24 +93,30 @@ public class TimerGuiManager {
         setStartButtonText(StartPause.START);
     }
 
-    public void reset() {
+    public void resetTime() {
         stop();
         timerManager.reset();
+        updateTimeDisplay();
+    }
+
+    public void resetIntervalAndTime() {
+        timerManager.resetInterval();
+        resetTime();
         updateDisplay();
     }
 
-    public void update() {
+    public void updateDisplay() {
         updateIntervalDisplay();
-        updateDisplay();
+        updateTimeDisplay();
     }
 
-    private void updateDisplay() {
+    private void updateTimeDisplay() {
         int timeLeft = timerManager.getTimeLeft();
-        updateDisplay(timeLeft);
+        updateTimeDisplay(timeLeft);
     }
 
     // Method to update the timer display
-    public void updateDisplay(int timeLeft) {
+    public void updateTimeDisplay(int timeLeft) {
         int minutes = timeLeft / 60;
         int seconds = timeLeft % 60;
         timerController.setTimerLabelText(String.format("%02d:%02d", minutes, seconds));
@@ -158,6 +164,6 @@ public class TimerGuiManager {
 
     public void debug() {
         timerManager.setTimeLeft(3);
-        updateDisplay();
+        updateTimeDisplay();
     }
 }

--- a/src/main/java/org/example/manager/TimerListManager.java
+++ b/src/main/java/org/example/manager/TimerListManager.java
@@ -69,9 +69,9 @@ public class TimerListManager {
         timerController.getTimerListView().getSelectionModel().selectedItemProperty().addListener((obs, oldVal, newVal) -> {
             if (newVal != null) {
                 timerGuiManager.setSelectedTimer(newVal);
-                timerGuiManager.reset();
+                timerGuiManager.resetIntervalAndTime();
             }
-            timerGuiManager.update();
+            timerGuiManager.updateDisplay();
            updateTimerList();
         });
     }

--- a/src/main/java/org/example/manager/TimerManager.java
+++ b/src/main/java/org/example/manager/TimerManager.java
@@ -38,7 +38,7 @@ public class TimerManager {
         if (timeLeft <= 0) {
             onComplete();
         } else {
-            timerGuiManager.updateDisplay(timeLeft);
+            timerGuiManager.updateTimeDisplay(timeLeft);
         }
     }
 
@@ -49,7 +49,7 @@ public class TimerManager {
         nextInterval();
         reset();
         start();
-        timerGuiManager.update();
+        timerGuiManager.updateDisplay();
     }
 
     // Method to handle timer completion
@@ -61,7 +61,7 @@ public class TimerManager {
 
         currentInterval++;
         if (currentInterval > selectedTimer.getPomodoroCount()) {
-            currentInterval = 1;
+            resetInterval();
             currentMode = TimerMode.LONG_BREAK;
         } else {
             currentMode = TimerMode.SHORT_BREAK;
@@ -102,5 +102,8 @@ public class TimerManager {
         return selectedTimer.getPomodoroCount();
     }
 
+    public void resetInterval() {
+        currentInterval = 1;
+    }
 }
 


### PR DESCRIPTION
Fix unintended behavior that did not reset the interval counter when switching between timers.

This could cause the application to hang if you tried to run the timer with an interval count higher then the allowed maximum.