### PR TITLE
Remove list update after selecting a timer

### DIFF
--- a/src/main/java/org/example/manager/TimerListManager.java
+++ b/src/main/java/org/example/manager/TimerListManager.java
@@ -72,7 +72,6 @@ public class TimerListManager {
                 timerGuiManager.reset();
             }
             timerGuiManager.update();
-           updateTimerList();
         });
     }
 }


### PR DESCRIPTION
Fix a bug that called update over and over after creating and selecting a timer causing the program to freeze.